### PR TITLE
Remove mistake import

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -2,7 +2,6 @@ import * as events from "events";
 import * as constants from "./constants";
 import WebSocket from "ws";
 
-import * as hello from "./packets/Hello";
 import {Data} from "./packets/Data";
 import {Hello} from "./packets/Hello";
 import {User} from "./types/User";


### PR DESCRIPTION
 ```typescript
import * as hello from "./packets/Hello";
``` 
https://github.com/Ale32bit/SwitchChat/blob/f9c195cdbb8383ba3ce6ef21732cc942c0378912/src/Client.ts#LL5

From what I can see, this is an unused import, and is probably a mistake.
You are also importing `Hello` on L7.
I might have prefixed my commit wrongly, so sorry for that.

```typescript
import {Hello} from "./packets/Hello";
```

https://github.com/Ale32bit/SwitchChat/blob/f9c195cdbb8383ba3ce6ef21732cc942c0378912/src/Client.ts#LL7
