### PR TITLE
docs: initial tsdoc effort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,7 @@ dist
 .yarn/unplugged
 .yarn/build-state.yml
 .pnp.*
+
+# TypeDoc output
+docs
+types

--- a/docs.Dockerfile
+++ b/docs.Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18-alpine
+WORKDIR /build
+COPY ["package.json", "package-lock.json", "./"]
+RUN npm install
+ENV NODE_ENV=production
+COPY . .
+RUN mkdir docs out
+RUN npm run docs
+CMD cp -r docs/* out/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "switchchat",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "switchchat",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/ws": "^8.5.4",
         "ws": "^8.12.0"
       },
       "devDependencies": {
+        "typedoc": "^0.23.26",
         "typescript": "^4.9.4"
       }
     },
@@ -29,6 +30,99 @@
         "@types/node": "*"
       }
     },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
+    "node_modules/marked": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
+      "integrity": "sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
+    "node_modules/typedoc": {
+      "version": "0.23.26",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.26.tgz",
+      "integrity": "sha512-5m4KwR5tOLnk0OtMaRn9IdbeRM32uPemN9kur7YK9wFqx8U0CYrvO9aVq6ysdZSV1c824BTm+BuQl2Ze/k1HtA==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.12",
+        "minimatch": "^7.1.3",
+        "shiki": "^0.14.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
@@ -41,6 +135,18 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
     },
     "node_modules/ws": {
       "version": "8.12.0",
@@ -77,10 +183,94 @@
         "@types/node": "*"
       }
     },
+    "ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
+    "marked": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
+      "integrity": "sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^2.0.1"
+      }
+    },
+    "shiki": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
+      "dev": true,
+      "requires": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
+    "typedoc": {
+      "version": "0.23.26",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.26.tgz",
+      "integrity": "sha512-5m4KwR5tOLnk0OtMaRn9IdbeRM32uPemN9kur7YK9wFqx8U0CYrvO9aVq6ysdZSV1c824BTm+BuQl2Ze/k1HtA==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.12",
+        "minimatch": "^7.1.3",
+        "shiki": "^0.14.1"
+      }
+    },
     "typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true
+    },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
     },
     "ws": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "types/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "echo \"Error: no test specified\""
+    "test": "echo \"Error: no test specified\"",
+    "docs": "typedoc"
   },
   "repository": {
     "type": "git",
@@ -14,6 +15,8 @@
   },
   "keywords": [
     "switchchat",
+    "switchcraft",
+    "sc3",
     "websocket"
   ],
   "author": "Alessandro \"AlexDevs\" Proto",
@@ -27,6 +30,7 @@
     "ws": "^8.12.0"
   },
   "devDependencies": {
+    "typedoc": "^0.23.26",
     "typescript": "^4.9.4"
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,10 @@
 export const endpoint = "wss://chat.sc3.io/v2/";
 
 export enum mode {
+    /** Discord-like [Markdown syntax](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-).
+     * Supports URLs, but not colours. */
     markdown = "markdown",
+    /** Minecraft-like [formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes) using ampersands (e.g. 
+     * `&e` for yellow). Supports colours, but not URLs. */
     format = "format"
 }

--- a/src/events/AFK.ts
+++ b/src/events/AFK.ts
@@ -2,5 +2,6 @@ import {BaseEvent} from "./BaseEvent";
 import {User} from "../types/User";
 
 export interface AFK extends BaseEvent {
-    user: User
+    /** The in-game player who went AFK. */
+    user: User;
 }

--- a/src/events/AFKReturn.ts
+++ b/src/events/AFKReturn.ts
@@ -2,5 +2,6 @@ import {BaseEvent} from "./BaseEvent";
 import {User} from "../types/User";
 
 export interface AFKReturn extends BaseEvent {
-    user: User
+    /** The in-game player who returned from being AFK. */
+    user: User;
 }

--- a/src/events/BaseEvent.ts
+++ b/src/events/BaseEvent.ts
@@ -1,7 +1,7 @@
 import {Data} from "../packets/Data";
 
 export interface BaseEvent extends Data {
-    id: number,
-    event: string,
-    time: Date,
+    id: number;
+    event: string;
+    time: Date;
 }

--- a/src/events/ChatboxChatMessage.ts
+++ b/src/events/ChatboxChatMessage.ts
@@ -2,11 +2,23 @@ import {BaseEvent} from "./BaseEvent";
 import {RenderedTextObject} from "../types/RenderedTextObject";
 import {User} from "../types/User";
 
+/** The event received when another chatbox sends a message. */
 export interface ChatboxChatMessage extends BaseEvent {
-    text: string,
-    rawText: string,
-    renderedText: RenderedTextObject,
-    user: User,
-    name: string,
-    rawName: string,
+    /** The message contents, without formatting codes. */
+    text: string;
+
+    /** The message contents, with its original formatting codes. */
+    rawText: string;
+
+    /** The message contents, serialised with formatting as Minecraft JSON text. */
+    renderedText: RenderedTextObject;
+
+    /** The owner of the chatbox that sent the message.  */
+    user: User;
+
+    /** The name of the chatbox, without formatting codes. */
+    name: string;
+
+    /** The name of the chatbox, with its original formatting codes. */
+    rawName: string;
 }

--- a/src/events/ChatboxCommand.ts
+++ b/src/events/ChatboxCommand.ts
@@ -1,9 +1,19 @@
 import {BaseEvent} from "./BaseEvent";
 import {User} from "../types/User";
 
+/** The event received when a player runs a chatbox command (public backslash commands: `\command`, private owner-only 
+ * caret/pipe commands: `^command`) in-game. The `command` capability is required to receive command events. */
 export interface ChatboxCommand extends BaseEvent {
-    user: User,
-    command: string,
-    args: string[],
-    ownerOnly: boolean
+    /** The in-game player who ran the command. */
+    user: User;
+
+    /** The name of the command (the word immediately following the backslash/caret/pipe, excluding the 
+     * backslash/caret/pipe). */
+    command: string;
+
+    /** Array of space-separated string arguments after the command. */
+    args: string[];
+
+    /** `true` if the command is an owner-only command (`^command`). */
+    ownerOnly: boolean;
 }

--- a/src/events/Death.ts
+++ b/src/events/Death.ts
@@ -2,10 +2,20 @@ import {BaseEvent} from "./BaseEvent";
 import {User} from "../types/User";
 import {RenderedTextObject} from "../types/RenderedTextObject";
 
+/** The event received when a player dies in-game. */
 export interface Death extends BaseEvent {
-    text: string,
-    rawText: string,
-    renderedText: RenderedTextObject,
-    user: User,
-    source: User,
+    /** The death message contents, without formatting codes. */
+    text: string;
+
+    /** The death message contents, with its original formatting codes. */
+    rawText: string;
+
+    /** The death message contents, serialised with formatting as Minecraft JSON text. */
+    renderedText: RenderedTextObject;
+
+    /** The in-game player who died. */
+    user: User;
+
+    /** The player that killed this player (if available), or `null`. */
+    source: User | null;
 }

--- a/src/events/DiscordChatMessage.ts
+++ b/src/events/DiscordChatMessage.ts
@@ -2,11 +2,23 @@ import {BaseEvent} from "./BaseEvent";
 import {RenderedTextObject} from "../types/RenderedTextObject";
 import {DiscordUser} from "../types/DiscordUser";
 
+/** The event received when a player posts a message in Discord. */
 export interface DiscordChatMessage extends BaseEvent {
-    text: string,
-    rawText: string,
-    renderedText: RenderedTextObject,
-    discordId: string,
-    discordUser: DiscordUser,
-    edited: boolean,
+    /** The message contents, without Markdown formatting codes. */
+    text: string;
+
+    /** The message contents, with its original Markdown formatting codes. */
+    rawText: string;
+
+    /** The message contents, serialised with formatting as Minecraft JSON text. */
+    renderedText: RenderedTextObject;
+
+    /** The Discord snowflake ID of this message. */
+    discordId: string;
+
+    /** The Discord user who sent the message. */
+    discordUser: DiscordUser;
+
+    /** `true` if this event represents an edit to the original message. */
+    edited: boolean;
 }

--- a/src/events/IngameChatMessage.ts
+++ b/src/events/IngameChatMessage.ts
@@ -2,9 +2,17 @@ import {BaseEvent} from "./BaseEvent";
 import {RenderedTextObject} from "../types/RenderedTextObject";
 import {User} from "../types/User";
 
+/** The event received when a player posts a message in public chat. */
 export interface IngameChatMessage extends BaseEvent {
-    text: string,
-    rawText: string,
-    renderedText: RenderedTextObject,
-    user: User,
+    /** The message contents, without formatting codes. */
+    text: string;
+
+    /** The message contents, with its original formatting codes. */
+    rawText: string;
+
+    /** The message contents, serialised with formatting as Minecraft JSON text. */
+    renderedText: RenderedTextObject;
+
+    /** The in-game player who sent the message. */
+    user: User;
 }

--- a/src/events/Join.ts
+++ b/src/events/Join.ts
@@ -1,6 +1,8 @@
 import {BaseEvent} from "./BaseEvent";
 import {User} from "../types/User";
 
+/** The event received when a player joins the game. */
 export interface Join extends BaseEvent {
-    user: User
+    /** The in-game player who joined. */
+    user: User;
 }

--- a/src/events/Leave.ts
+++ b/src/events/Leave.ts
@@ -1,6 +1,8 @@
 import {BaseEvent} from "./BaseEvent";
 import {User} from "../types/User";
 
+/** The event received when a player leaves the game. */
 export interface Leave extends BaseEvent {
-    user: User
+    /** The in-game player who left. */
+    user: User;
 }

--- a/src/events/ServerRestartCancelled.ts
+++ b/src/events/ServerRestartCancelled.ts
@@ -1,0 +1,9 @@
+import {BaseEvent} from "./BaseEvent";
+
+export interface ServerRestartCancelled extends BaseEvent {
+    /** The type of restart. Will be `automatic` or `manual`. */
+    restartType: "automatic" | "manual";
+    
+    /** The time that this restart was cancelled. */
+    time: Date;
+}

--- a/src/events/ServerRestartScheduled.ts
+++ b/src/events/ServerRestartScheduled.ts
@@ -1,0 +1,15 @@
+import {BaseEvent} from "./BaseEvent";
+
+export interface ServerRestartScheduled extends BaseEvent {
+    /** The type of restart. Will be `automatic` or `manual`. */
+    restartType: "automatic" | "manual";
+
+    /** The number of seconds specified until the server restart. */
+    restartSeconds: number;
+
+    /** The time that the server will restart. */
+    restartAt: Date;
+    
+    /** The time that this restart was scheduled. */
+    time: Date;
+}

--- a/src/packets/Closing.ts
+++ b/src/packets/Closing.ts
@@ -1,6 +1,14 @@
 import {Data} from "./Data";
 
+/** 
+ * When your websocket connection is being closed by the server, you may receive a Closing packet.
+ * 
+ * @see https://docs.sc3.io/chatbox/websocket.html#closing-packet
+ */
 export interface Closing extends Data {
+    /** The reason your connection is being closed. */
     closeReason: string;
+
+    /** A human-readable message describing the close reason. */
     reason: string;
 }

--- a/src/packets/Error.ts
+++ b/src/packets/Error.ts
@@ -1,7 +1,16 @@
 import {Data} from "./Data";
 
+/** 
+ * Sent by the server when an error occurs.
+ * 
+ * @see https://docs.sc3.io/chatbox/websocket.html#error-packet
+ */
 export interface Error extends Data {
     id: number | undefined;
+
+    /** The type of error that occurred. */
     error: string;
+
+    /** A human-readable message describing the error. */
     message: string;
 }

--- a/src/packets/Hello.ts
+++ b/src/packets/Hello.ts
@@ -1,7 +1,7 @@
 import {Data} from "./Data";
 
 export interface Hello extends Data {
-    guest: boolean,
-    licenseOwner: string,
-    capabilities: string[],
+    guest: boolean;
+    licenseOwner: string;
+    capabilities: string[];
 }

--- a/src/packets/Players.ts
+++ b/src/packets/Players.ts
@@ -2,6 +2,6 @@ import {Data} from "./Data";
 import {User} from "../types/User";
 
 export interface Players extends Data {
-    time: string,
-    players: User[]
+    time: string;
+    players: User[];
 }

--- a/src/packets/Success.ts
+++ b/src/packets/Success.ts
@@ -1,6 +1,10 @@
 import {Data} from "./Data";
 
+/** Sent by the server when a message is sent or queued successfully. */
 export interface Success extends Data {
     id: number;
+
+    /** More information about the success. When sending messages, this may be
+     * `message_sent` or `message_queued`. */
     reason: string;
 }

--- a/src/types/Capabilities.ts
+++ b/src/types/Capabilities.ts
@@ -1,0 +1,1 @@
+export type Capability = "read" | "command" | "say" | "tell";

--- a/src/types/DiscordUser.ts
+++ b/src/types/DiscordUser.ts
@@ -1,15 +1,34 @@
-export type DiscordUser = {
-    type: string,
-    id: string,
-    name: string,
+export interface DiscordUser {
+    /** The type of user. For Discord events, this is always `discord`. */
+    type: "discord";
+
+    /** The user's Discord snowflake (ID). */
+    id: string;
+
+    /** The user's username on Discord. */
+    name: string;
+
+    /** The user's server nickname on Discord, or their username if it is not
+     * set. */
     displayName: string;
+
+    /** The user's discriminator on Discord. */
     discriminator: string;
+
+    /** URL to the user's avatar on Discord. */
     avatar: string;
-    roles: [
-        {
-            id: string,
-            name: string,
-            colour: number
-        }
-    ]
+
+    /** Array of roles the user has on Discord. */
+    roles: DiscordRole[];
+}
+
+export interface DiscordRole {
+    /** The role's Discord snowflake (ID). */
+    id: string;
+
+    /** The name of the role. */
+    name: string;
+
+    /** The colour of the role, as a 24-bit integer (0xFFFFFF). */
+    colour: number;
 }

--- a/src/types/QueueMessage.ts
+++ b/src/types/QueueMessage.ts
@@ -2,15 +2,16 @@ import * as constants from "../constants";
 import {Success} from "../packets/Success";
 import {Error} from "../packets/Error";
 
-export type QueueMessage = {
+/** @internal */
+export interface QueueMessage {
     data: {
-        id: number,
+        id: number;
         type: string;
         user?: string;
         name: string | undefined;
         text: string;
         mode: constants.mode;
-    },
+    };
     resolve: (value: Success) => void;
     reject: (reason: Error) => void;
 }

--- a/src/types/RenderedTextObject.ts
+++ b/src/types/RenderedTextObject.ts
@@ -1,7 +1,16 @@
+/** 
+ * Minecraft-compatible raw JSON text.
+ * 
+ * @see https://minecraft.fandom.com/wiki/Raw_JSON_text_format
+ */
 export interface RenderedTextObject {
-    extra: {
-        [key: string]: any,
-        text: string,
-    }[];
+    // TODO: This is actually optional. Text may be different content types,
+    //       such as `translate` and `score`.
     text: string;
+
+    /** A list of additional raw JSON text components to be displayed after this
+     * one. */
+    extra: RenderedTextObject[];
+
+    [key: string]: any;
 }

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,9 +1,30 @@
-export type User = {
-    type: string;
-    group: string;
-    world?: string;
+export interface User {
+    /** The type of user. For in-game events, this is always `ingame`. */
+    type: "ingame";
+
+    /** The rank of the player. Usually `default`, `moderator`, or `admin`, but 
+     * the server may send anything. */
+    group: "default" | "moderator" | "admin" | string;
+
+    /** 
+     * The world the player is in, or `null` if this information is not 
+     * available. It will be a Minecraft namespaced registry key, for example:
+     * 
+     * - `minecraft:overworld` - The overworld
+     * - `minecraft:the_nether` - The nether
+     * - `minecraft:the_end` - The end
+     */
+    world: string | null;
+
+    /** The UUID of the player, including hyphens. */
     uuid: string;
+
+    /** The player's name as it appears in chat. May differ from `name`. */
     displayName: string;
+
+    /** The player's Minecraft username. */
     name: string;
+
+    /** Whether the player is currently AFK. */
     afk?: boolean;
 }

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "tagDefinitions": [
+    {
+      "tagName": "@group",
+      "syntaxKind": "block"
+    },
+    {
+      "tagName": "@event",
+      "syntaxKind": "block"
+    }
+  ]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "out": "docs",
+  "name": "SwitchChat API reference",
+  "includeVersion": true,
+  "excludeInternal": true
+}


### PR DESCRIPTION
Initial work on populating the codebase with more [tsdoc](https://tsdoc.org/) and generating it with [typedoc](https://typedoc.org/).

The plan is to work in tandem with #9 to achieve something similar to krist.js:

- The start for the README.md (for GitHub and npm) will be handled by @Erb3 in #9
- Extended markdown-based docs with more detail and examples will be included in [sc-docs](https://github.com/SwitchCraftCC/sc-docs) alongside the ComputerCraft page. The basis for these will be the existing Websocket docs and @Erb3's code examples in #9 
- Visibility for the library will be increased in sc-docs
- (This PR) tsdocs for the actual types and API methods inline in the code, for IDE integration and for a TypeDoc-based web reference

I have spoken to Erb3 to make sure they are aware of this rough plan.

A Dockerfile is included for generating the documentation - I will use this on the sc-docs webserver.

This PR also makes the following additional changes and type corrections, feel free to remove/reject any as you wish:

- Replaces the `string` type of `capabilities` with a `Capability` enum
- Adds interfaces for `server_restart_scheduled` and `server_restart_cancelled` events
- Coerces the type of `restartAt` in `server_restart_scheduled` to `Date`
- Changes type of `Death.source` from `User | undefined` to `User | null`
- Adds explicit `DiscordRole` type
- Changes `RenderedTextObject` to more accurately reflect the recursive nature of `extra`
- Changes type of `User.world` from `string | undefined` to `string | null`