### PR TITLE
Fix wrong documentation for Client.say and Client.tell.

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ You can run these methods on your [`Client`](https://docs.sc3.io/library/switchc
 
 Sends a message to the in-game public chat. Returns a Promise that resolves to a
 [Success](https://docs.sc3.io/library/switchchat/interfaces/Success.html) object, which will tell you if the message
-was sent (`reason` is `"message_sent"`) or queued (`reason` is `"message_queued"`).
+was sent (`reason` is `"message_sent"`).
 
 | Argument | Type                | Description                                                                                                                              |
 |----------|---------------------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -286,7 +286,7 @@ was sent (`reason` is `"message_sent"`) or queued (`reason` is `"message_queued"
 
 Sends a private message to an in-game player. Returns a Promise that resolves to a 
 [Success](https://docs.sc3.io/library/switchchat/interfaces/Success.html) object, which will tell you if the message
-was sent (`reason` is `"message_sent"`) or queued (`reason` is `"message_queued"`).
+was sent (`reason` is `"message_sent"`).
 
 | Argument | Type                | Description                                                                                                                              |
 |----------|---------------------|------------------------------------------------------------------------------------------------------------------------------------------|

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -72,7 +72,7 @@ export declare interface Client {
      * 
      *   If no mode is specified, it will default to the mode specified in the constructor.
      * 
-     * @returns A {@link Success} object containing whether the message was sent or queued.
+     * @returns A {@link Success} object containing if the message was sent.
      */
     say(text: string, name?: string, mode?: FormattingMode): Promise<Success>;
 
@@ -91,7 +91,7 @@ export declare interface Client {
      * 
      *   If no mode is specified, it will default to the mode specified in the constructor.
      * 
-     * @returns A {@link Success} object containing whether the message was sent or queued.
+     * @returns A {@link Success} object containing if the message was sent.
      */
     tell(user: string, text: string, name?: string, mode?: FormattingMode): Promise<Success>;
 


### PR DESCRIPTION
`Client.say` and `Client.tell` are not fulfilled on `message_queued`.

See the following line, Promises are fulfilled only on `message_sent`:
https://github.com/Ale32bit/SwitchChat/blob/5cfddb13e9e2ba50bde985fa7e23e39393be136f/src/Client.ts#L336-L342