### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ The Discord user object represents a user on Discord.
 ([Websocket API docs](https://docs.sc3.io/chatbox/websocket.html#raw-json-text-object) &ndash;
 [API reference](https://docs.sc3.io/library/switchchat/interfaces/RenderedTextObject.html))
 
-Minecraft's serialised [raw JSON text format](https://minecraft.fandom.com/wiki/Raw_JSON_text_format). See the [SwitchCraft documentation](https://docs.sc3.io/chatbox/websocket.html#raw-json-text-object) for more information on how this is used.
+Minecraft's serialised [raw JSON text format](https://minecraft.wiki/w/Raw_JSON_text_format). See the [SwitchCraft documentation](https://docs.sc3.io/chatbox/websocket.html#raw-json-text-object) for more information on how this is used.
 
 ### FormattingMode
 
@@ -399,4 +399,4 @@ Minecraft's serialised [raw JSON text format](https://minecraft.fandom.com/wiki/
 The mode to use for outgoing chatbox messages (`.say()`, `.tell()`).
 
 - markdown - Discord-like [Markdown syntax](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-). Supports URLs, but not colours.
-- format - Minecraft-like [formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes) using ampersands (e.g. `&e` for yellow). Supports colours, but not URLs.
+- format - Minecraft-like [formatting codes](https://minecraft.wiki/w/Formatting_codes) using ampersands (e.g. `&e` for yellow). Supports colours, but not URLs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "switchchat",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "switchchat",
-      "version": "3.1.3",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@types/ws": "^8.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "switchchat",
-  "version": "3.2.1",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "switchchat",
-      "version": "3.2.1",
+      "version": "3.1.3",
       "license": "MIT",
       "dependencies": {
         "@types/ws": "^8.5.4",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -73,7 +73,7 @@ export declare interface Client {
      * @param mode The formatting mode to use. You can use these formatting modes:
      *   - `markdown` - Discord-like [Markdown syntax](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-).
      *      Supports URLs, but not colours.
-     *   - `format` - Minecraft-like [formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes) using
+     *   - `format` - Minecraft-like [formatting codes](https://minecraft.wiki/w/Formatting_codes) using
      *      ampersands (e.g. `&e` for yellow). Supports colours, but not URLs.
      *
      *   If no mode is specified, it will default to the mode specified in the constructor.
@@ -92,7 +92,7 @@ export declare interface Client {
      * @param mode The formatting mode to use. You can use these formatting modes:
      *   - `markdown` - Discord-like [Markdown syntax](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-).
      *      Supports URLs, but not colours.
-     *   - `format` - Minecraft-like [formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes) using
+     *   - `format` - Minecraft-like [formatting codes](https://minecraft.wiki/w/Formatting_codes) using
      *      ampersands (e.g. `&e` for yellow). Supports colours, but not URLs.
      *
      *   If no mode is specified, it will default to the mode specified in the constructor.

--- a/src/types/RenderedTextObject.ts
+++ b/src/types/RenderedTextObject.ts
@@ -1,7 +1,7 @@
 /** 
  * Minecraft-compatible raw JSON text.
  * 
- * @see https://minecraft.fandom.com/wiki/Raw_JSON_text_format
+ * @see https://minecraft.wiki/w/Raw_JSON_text_format
  */
 export interface RenderedTextObject {
     // TODO: This is actually optional. Text may be different content types,
@@ -20,7 +20,7 @@ export interface RenderedTextObject {
  *
  * - `markdown` - Discord-like [Markdown syntax](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-).
  *   Supports URLs, but not colours.
- * - `format` - Minecraft-like [formatting codes](https://minecraft.fandom.com/wiki/Formatting_codes) using ampersands
+ * - `format` - Minecraft-like [formatting codes](https://minecraft.wiki/w/Formatting_codes) using ampersands
  *  (e.g. `&e` for yellow). Supports colours, but not URLs.
  */
 export type FormattingMode = "markdown" | "format";


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.